### PR TITLE
Fix failing build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,36 @@
+name: Build and Test
+on: push
+
+jobs:
+  test:
+    strategy:
+      # Fail fast can be set to false to allow all jobs in matrix to complete
+      # even if one fails. Default is true.
+      # fail-fast: false
+      matrix:
+        # Define variables and their values
+        os: [macos-latest, ubuntu-latest]
+        swift: ['5.10', '6.0']
+        # Can include other variables like configurations
+        config: [debug, release]
+
+        # Can exclude specific combinations if needed
+        # exclude:
+        #   - os: ubuntu-latest
+        #     swift: '5.9'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Swift ${{ matrix.swift }} on ${{ matrix.os }}
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: ${{ matrix.swift }}
+
+      - name: Build for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
+        run: swift build -c ${{ matrix.config }}
+        
+      - name: Test for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
+        run: swift test -c ${{ matrix.config }}

--- a/Sources/Archivist/Macro.swift
+++ b/Sources/Archivist/Macro.swift
@@ -1,5 +1,3 @@
-import ArchivistMacros
-
 @attached(member, names: named(init), named(write))
 @attached(extension, conformances: Archivable)
 public macro Archivable() = #externalMacro(module: "ArchivistMacros", type: "ArchivableMacro")

--- a/Sources/ArchivistMacros/ArchivistMacros.swift
+++ b/Sources/ArchivistMacros/ArchivistMacros.swift
@@ -211,7 +211,7 @@ extension ArchivableMacro: MemberMacro {
 }
 
 @main
-struct AcrhivistMacros: CompilerPlugin {
+struct ArchivistMacros: CompilerPlugin {
 
   var providingMacros: [Macro.Type] = [ArchivableMacro.self]
 


### PR DESCRIPTION
Fix AcrhivistMacros typo and remove extra import that causes build failing.

Build failure:
```
/home/ambrus/ArchivistFork/Sources/Archivist/Macro.swift:1:8: error: no such module 'ArchivistMacros'
1 | import ArchivistMacros
  |        `- error: no such module 'ArchivistMacros'
2 | 
3 | @attached(member, names: named(init), named(write))
note: module 'ArchivistMacros' is a macro, and cannot be imported by tests and other targets
```

Removing the import statement fixed the issue. I also fixed a typo in `Sources/ArchivistMacros/ArchivistMacros.swift` but that was independent from this issue.