### PR TITLE
Replace 'compactMap' with 'map'

### DIFF
--- a/Sources/ArchivistMacros/SwiftSyntax+Extensions.swift
+++ b/Sources/ArchivistMacros/SwiftSyntax+Extensions.swift
@@ -6,7 +6,7 @@ extension PatternBindingSyntax {
   var isComputedProperty: Bool {
     switch accessorBlock?.accessors {
     case .some(.accessors(let a)):
-      for k in a.compactMap(\.accessorSpecifier.tokenKind) {
+      for k in a.map(\.accessorSpecifier.tokenKind) {
         if (k == .keyword(.didSet)) || (k == .keyword(.willSet)) { return true }
       }
       return false


### PR DESCRIPTION
This change is an attempt to fix the CI failure on Swift 5.10.