### PR TITLE
Remove Swift 5.10 testing and clean up CI script

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,15 +4,12 @@ on: push
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         # Note: all combinations of the following will be run independently
         os: [ macos-latest, ubuntu-latest ]
         swift: [ '6.1' ]
         config: [ debug, release ]
-
-        # Fail fast can be set to false to allow all jobs in matrix to complete
-        # even if one fails. Default is true.
-        # fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [macos-latest, ubuntu-latest]
-        swift: ["6.1.1", "6.1", "6.0"]
+        swift: ["6.0"] # Update to 6.1 after this is fixed: https://github.com/swiftlang/swift/issues/81768
         config: [release, debug]
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [ macos-latest, ubuntu-latest ]
-        swift: ['6.0', '6.1' ]
+        swift: ['6.1' ]
         config: [ debug, release ]
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,22 +4,15 @@ on: push
 jobs:
   test:
     strategy:
-      # Fail fast can be set to false to allow all jobs in matrix to complete
-      # even if one fails. Default is true.
-      # fail-fast: false
       matrix:
-        # Define variables and their values
-        os: [macos-latest, ubuntu-latest]
-        swift: ['5.10', '6.0']
-        # Can include other variables like configurations
-        config: [debug, release]
+        # Note: all combinations of the following will be run independently
+        os: [ macos-latest, ubuntu-latest ]
+        swift: [ '6.0' ]
+        config: [ debug, release ]
 
-        # Can exclude specific combinations if needed
-        # exclude:
-        #   - os: ubuntu-latest
-        #     swift: '5.9'
-
-    runs-on: ${{ matrix.os }}
+        # Fail fast can be set to false to allow all jobs in matrix to complete
+        # even if one fails. Default is true.
+        # fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +24,8 @@ jobs:
 
       - name: Build for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
         run: swift build -c ${{ matrix.config }}
-        
+
       - name: Test for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
         run: swift test -c ${{ matrix.config }}
+
+    runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,8 +8,8 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [macos-latest, ubuntu-latest]
-        swift: ["6.1.1"]
-        config: [release]
+        swift: ["6.1.1", "6.1", "6.0"]
+        config: [release, debug]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,9 @@ jobs:
       fail-fast: false
       matrix:
         # Note: all combinations of the following will be run independently
-        os: [ macos-latest, ubuntu-latest ]
-        swift: ['6.1' ]
-        config: [ debug, release ]
+        os: [macos-latest, ubuntu-latest]
+        swift: ["6.1.1"]
+        config: [debug, release]
 
     steps:
       - uses: actions/checkout@v4
@@ -19,10 +19,13 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
 
-      - name: Build for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
-        run: swift build -c ${{ matrix.config }}
+      # We disabled the separate build step, as it consumes extra CI time - building for testing apparently doesn't 
+      # reuse the build cache from here, doubling the CI time.
 
-      - name: Test for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
+      # - name: Build for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
+      #   run: swift build -c ${{ matrix.config }}
+
+      - name: Build & Test for ${{ matrix.swift }} on ${{ matrix.os }} with ${{ matrix.config }} configuration
         run: swift test -c ${{ matrix.config }}
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
         # Note: all combinations of the following will be run independently
         os: [macos-latest, ubuntu-latest]
         swift: ["6.1.1"]
-        config: [debug, release]
+        config: [release]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [ macos-latest, ubuntu-latest ]
-        swift: [ '6.0' ]
+        swift: [ '6.1' ]
         config: [ debug, release ]
 
         # Fail fast can be set to false to allow all jobs in matrix to complete

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Note: all combinations of the following will be run independently
         os: [ macos-latest, ubuntu-latest ]
-        swift: [ '6.1' ]
+        swift: ['6.0', '6.1' ]
         config: [ debug, release ]
 
     steps:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c4667e14b7600077aecf4251ab9a2981dc61bee154c6a14dcc283ebfb6c69996",
+  "originHash" : "678c523895b6a58193145ae74758aca051b377b6243310c8159250f09a4206fa",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.1
 import CompilerPluginSupport
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Archivist", targets: ["Archivist"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax", from: "601.0.1"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.0
 import CompilerPluginSupport
 import PackageDescription
 

--- a/Sources/ArchivistMacros/ArchivistMacros.swift
+++ b/Sources/ArchivistMacros/ArchivistMacros.swift
@@ -39,7 +39,6 @@ extension ArchivableMacro: MemberMacro {
     // Ignore the `conformingTo` parameter for now, delegate to the existing implementation.
     try expansion(of: attribute, providingMembersOf: decl, in: context)
   }
-  
 
   public static func expansion<Decl: DeclGroupSyntax, Context: MacroExpansionContext>(
     of attribute: AttributeSyntax,

--- a/Sources/ArchivistMacros/SwiftSyntax+Extensions.swift
+++ b/Sources/ArchivistMacros/SwiftSyntax+Extensions.swift
@@ -40,7 +40,7 @@ extension VariableDeclSyntax {
 
   /// `true` iff `self` denotes a computed property.
   var isComputedProperty: Bool {
-    if let b = bindings.uniqueElement?.as(PatternBindingSyntax.self) {
+    if let b = bindings.uniqueElement {
       return b.isComputedProperty
     } else {
       return false


### PR DESCRIPTION
I removed support for Swift 5.10 and removed the sepate build step to speed up the CI (now build & test happens together).

I reported an issue with the Swift Compiler crashing in SILMem2Reg optimization pass on MacOS using Swift 6.1, so I disabled 6.1 testing for now. 
https://github.com/swiftlang/swift/issues/81768