### PR TITLE
Upgrade swift-syntax dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "678c523895b6a58193145ae74758aca051b377b6243310c8159250f09a4206fa",
+  "originHash" : "0f3eebf7ee2935e711f94eceddb58323a04ddb983f26850b2103ec780c08b94d",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .library(name: "Archivist", targets: ["Archivist"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", from: "601.0.1"),
+    .package(url: "https://github.com/apple/swift-syntax", from: "602.0.0"),
   ],
   targets: [
     .target(


### PR DESCRIPTION
There were [some build warnings](https://github.com/swiftlang/swift/issues/86833) caused by the older version of swift-syntax, so this PR updates the dependency to the newest release.